### PR TITLE
Refactor to make termd pluggable other WebSockets implementations

### DIFF
--- a/src/main/java/io/termd/core/http/HttpTtyConnection.java
+++ b/src/main/java/io/termd/core/http/HttpTtyConnection.java
@@ -50,6 +50,7 @@ public abstract class HttpTtyConnection implements TtyConnection {
   private final BinaryDecoder decoder;
   private final BinaryEncoder encoder;
   private Consumer<Void> closeHandler;
+  private String invokerContext;
 
   public HttpTtyConnection() {
     readBuffer = new ReadBuffer(command -> {
@@ -59,6 +60,11 @@ public abstract class HttpTtyConnection implements TtyConnection {
     onCharSignalDecoder = new TtyEventDecoder(3, 26, 4).setReadHandler(readBuffer);
     decoder = new BinaryDecoder(512, TelnetCharset.INSTANCE, onCharSignalDecoder);
     encoder = new BinaryEncoder(512, StandardCharsets.US_ASCII, this::write);
+  }
+
+  public HttpTtyConnection(String invokerContext) {
+    this();
+    this.invokerContext = invokerContext;
   }
 
   protected abstract void write(byte[] buffer);
@@ -71,6 +77,10 @@ public abstract class HttpTtyConnection implements TtyConnection {
         decoder.write(data.getBytes()); //write back echo
         break;
     }
+  }
+
+  public String getInvokerContext() {
+    return invokerContext;
   }
 
   public Consumer<String> termHandler() {

--- a/src/main/java/io/termd/core/pty/PtyBootstrap.java
+++ b/src/main/java/io/termd/core/pty/PtyBootstrap.java
@@ -81,14 +81,14 @@ public class PtyBootstrap implements Consumer<TtyConnection> {
         System.out.println("CLIENT $TERM=" + term);
     });
     conn.writeHandler().accept(Helper.toCodePoints("Welcome sir\r\n"));
-    read(conn, readline);
+    read(conn, readline, conn.getInvokerContext());
   }
 
-  public void read(final TtyConnection conn, final Readline readline) {
+  public void read(final TtyConnection conn, final Readline readline, String invokerContext) {
     Consumer<String> requestHandler = new Consumer<String>() {
       @Override
       public void accept(String line) {
-        PtyMaster task = new PtyMaster(PtyBootstrap.this, conn, readline, line);
+        PtyMaster task = new PtyMaster(PtyBootstrap.this, conn, readline, line, invokerContext);
         taskCreationListener.accept(task);
         task.start();
       }

--- a/src/main/java/io/termd/core/pty/PtyMaster.java
+++ b/src/main/java/io/termd/core/pty/PtyMaster.java
@@ -18,8 +18,8 @@ package io.termd.core.pty;
 
 import io.termd.core.io.BinaryDecoder;
 import io.termd.core.readline.Readline;
-import io.termd.core.tty.TtyEvent;
 import io.termd.core.tty.TtyConnection;
+import io.termd.core.tty.TtyEvent;
 import io.termd.core.util.Helper;
 
 import java.io.IOException;
@@ -46,13 +46,15 @@ public class PtyMaster extends Thread {
   private Consumer<int[]> processOutputConsumer;
   private Consumer<String> processInputConsumer;
   private Status status;
+  private String invokerContext; //Context is attached to the PtyStatusEvent
 
-  public PtyMaster(PtyBootstrap bootstrap, TtyConnection conn, Readline readline, String line) {
+  public PtyMaster(PtyBootstrap bootstrap, TtyConnection conn, Readline readline, String line, String invokerContext) {
     this.bootstrap = bootstrap;
     this.conn = conn;
     this.readline = readline;
     this.line = line;
     status = Status.NEW;
+    this.invokerContext = invokerContext;
   }
 
   public void setProcessOutputConsumer(Consumer<int[]> processOutputConsumer) {
@@ -171,13 +173,13 @@ public class PtyMaster extends Thread {
 
     // Read line again
     conn.setEventHandler(null);
-    conn.schedule(() -> bootstrap.read(conn, readline));
+    conn.schedule(() -> bootstrap.read(conn, readline, invokerContext));
   }
 
   private void setStatus(Status status) {
     Status old = this.status;
     this.status = status;
-    PtyStatusEvent statusUpdateEvent = new PtyStatusEvent(this, old, status);
+    PtyStatusEvent statusUpdateEvent = new PtyStatusEvent(this, old, status, invokerContext);
     if (taskStatusUpdateListener != null) {
       taskStatusUpdateListener.accept(statusUpdateEvent);
     }

--- a/src/main/java/io/termd/core/pty/PtyMaster.java
+++ b/src/main/java/io/termd/core/pty/PtyMaster.java
@@ -142,14 +142,10 @@ public class PtyMaster extends Thread {
       Pipe stderr = new Pipe(process.getErrorStream());
       stdout.start();
       stderr.start();
+      int exitValue = -1;
       try {
         process.waitFor();
-        int exitValue = process.exitValue();
-        if (exitValue == 0) {
-          setStatus(Status.COMPLETED);
-        } else {
-          setStatus(Status.FAILED);
-        }
+        exitValue = process.exitValue();
       } catch (InterruptedException e) {
         setStatus(Status.INTERRUPTED);
         Thread.currentThread().interrupt();
@@ -163,6 +159,11 @@ public class PtyMaster extends Thread {
         stderr.join();
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
+      }
+      if (exitValue == 0) {
+        setStatus(Status.COMPLETED);
+      } else {
+        setStatus(Status.FAILED);
       }
     } catch (IOException e) {
       conn.writeHandler().accept(Helper.toCodePoints(e.getMessage() + "\r\n"));

--- a/src/main/java/io/termd/core/pty/PtyStatusEvent.java
+++ b/src/main/java/io/termd/core/pty/PtyStatusEvent.java
@@ -23,11 +23,13 @@ public class PtyStatusEvent {
   private PtyMaster process;
   private Status oldStatus;
   private Status newStatus;
+  private String context;
 
-  public PtyStatusEvent(PtyMaster task, Status oldStatus, Status newStatus) {
+  public PtyStatusEvent(PtyMaster task, Status oldStatus, Status newStatus, String context) {
     this.process = task;
     this.oldStatus = oldStatus;
     this.newStatus = newStatus;
+    this.context = context;
   }
 
   public PtyMaster getProcess() {
@@ -42,4 +44,7 @@ public class PtyStatusEvent {
     return newStatus;
   }
 
+  public String getContext() {
+    return context;
+  }
 }

--- a/src/main/java/io/termd/core/tty/TtyConnection.java
+++ b/src/main/java/io/termd/core/tty/TtyConnection.java
@@ -77,4 +77,7 @@ public interface TtyConnection {
    */
   void schedule(Runnable task);
 
+  default String getInvokerContext() {
+    return null;
+  }
 }

--- a/src/main/resources/io/termd/core/term/terminfo.src
+++ b/src/main/resources/io/termd/core/term/terminfo.src
@@ -183,7 +183,7 @@
 # code packaged with ncurses and contemplating the resulting error messages.
 # In many cases, these indicated obvious fixes to syntax garbled by the
 # composers.  In a few cases, I was able to deduce corrected forms for garbled
-# capabilities by looking at context.  All the information in the original
+# capabilities by looking at invokerContext.  All the information in the original
 # entries is preserved in the comments.
 #
 # In the comments, terminfo capability names are bracketed with <> (angle
@@ -12227,10 +12227,10 @@ aaa-30-s|aaa-s|ann arbor ambassador/30 lines w/status,
 	tsl=\E[>51h\E[1;%p1%dH\E[2K, use=aaa+unk,
 aaa-30-s-rv|aaa-s-rv|ann arbor ambassador/30 lines+status+reverse video,
 	use=aaa+rv, use=aaa-30-s,
-aaa-s-ctxt|aaa-30-s-ctxt|ann arbor ambassador/30 lines+status+save context,
+aaa-s-ctxt|aaa-30-s-ctxt|ann arbor ambassador/30 lines+status+save invokerContext,
 	rmcup=\E[60;1;0;30p\E[59;1H\E[K,
 	smcup=\E[30;1H\E[K\E[30;1;0;30p, use=aaa-30-s,
-aaa-s-rv-ctxt|aaa-30-s-rv-ct|ann arbor ambassador/30 lines+status+save context+reverse video,
+aaa-s-rv-ctxt|aaa-30-s-rv-ct|ann arbor ambassador/30 lines+status+save invokerContext+reverse video,
 	rmcup=\E[60;1;0;30p\E[59;1H\E[K,
 	smcup=\E[30;1H\E[K\E[30;1;0;30p, use=aaa-30-s-rv,
 aaa|aaa-30|ambas|ambassador|ann arbor ambassador/30 lines,
@@ -12240,10 +12240,10 @@ aaa|aaa-30|ambas|ambassador|ann arbor ambassador/30 lines,
 	smcup=\E[H\E[J$<156>\E[30;0;0;30p, use=aaa+unk,
 aaa-30-rv|aaa-rv|ann arbor ambassador/30 lines in reverse video,
 	use=aaa+rv, use=aaa-30,
-aaa-30-ctxt|aaa-ctxt|ann arbor ambassador/30 lines; saving context,
+aaa-30-ctxt|aaa-ctxt|ann arbor ambassador/30 lines; saving invokerContext,
 	rmcup=\E[60;0;0;30p\E[60;1H\E[K, smcup=\E[30;0;0;30p,
 	use=aaa-30,
-aaa-30-rv-ctxt|aaa-rv-ctxt|ann arbor ambassador/30 lines reverse video; saving context,
+aaa-30-rv-ctxt|aaa-rv-ctxt|ann arbor ambassador/30 lines reverse video; saving invokerContext,
 	rmcup=\E[60;0;0;30p\E[60;1H\E[K, smcup=\E[30;0;0;30p,
 	use=aaa+rv, use=aaa-30,
 aaa-36|ann arbor ambassador/36 lines,
@@ -12301,7 +12301,7 @@ guru+s|guru status line,
 	dsl=\E7\E[;0p\E[1;1H\E[K\E[H\E8\r\n\E[K, fsl=\E[>51l,
 	rmcup=\E[255;1p\E[255;1H\E[K, smcup=,
 	tsl=\E[>51h\E[1;%p1%dH\E[2K,
-guru-nctxt|guru with no saved context,
+guru-nctxt|guru with no saved invokerContext,
 	smcup=\E[H\E[J$<156>\E[33p\E[255;1H\E[K, use=guru,
 guru-s|guru-33-s|ann arbor guru/33 lines+status,
 	lines#32,
@@ -14245,7 +14245,7 @@ ts100|ts100-sp|falco ts100-sp,
 	sgr0=\E[m\017$<2>, smacs=^N, smam=\E[?7h, smkx=\E[?1h\E=,
 	smso=\E[1;7m$<2>, smul=\E[4m$<2>, tbc=\E[3g,
 	use=vt100+fnkeys,
-ts100-ctxt|falco ts-100 saving context,
+ts100-ctxt|falco ts-100 saving invokerContext,
 	rmcup=\E~_b, smcup=\E~_d\E[2J, use=ts100,
 
 #### Florida Computer Graphics
@@ -22869,7 +22869,7 @@ v3220|LANPAR Vision II model 3220/3221/3222,
 #	* add/use xterm+tmux chunk from xterm #271 -TD
 #	* resync xterm-new entry from xterm #271 -TD
 #	* add E3 extended capability to linux-basic (Miroslav Lichvar)
-#	* add linux2.2, linux2.6, linux3.0 entries to give context for E3 -TD
+#	* add linux2.2, linux2.6, linux3.0 entries to give invokerContext for E3 -TD
 #	* add SI/SO change to linux2.6 entry (Debian #515609) -TD
 #
 # 2011-07-21


### PR DESCRIPTION
Refactor to allow usage of non vertex websocket implemtations.
Adds an option to register to process status updates.
Adds an option to add additional byteHandler, used to write process output to a log file in addition to a websocket channel.