### PR TITLE
Shutdown EventLoopGroup on telnet server stop

### DIFF
--- a/src/main/java/io/termd/core/telnet/netty/NettyTelnetBootstrap.java
+++ b/src/main/java/io/termd/core/telnet/netty/NettyTelnetBootstrap.java
@@ -90,5 +90,6 @@ public class NettyTelnetBootstrap extends TelnetBootstrap {
       doneHandler.accept(future.cause());
     };
     channelGroup.close().addListener(adapter);
+    group.shutdownGracefully();
   }
 }


### PR DESCRIPTION
Threads from the netty telnet server were staying alive and unable to be killed externally even after calling stop() on the telnet server. This change cleans up the threads when stop() is called.
