### PR TITLE
Replace invalid input byte sequence.

### DIFF
--- a/src/main/java/io/termd/core/io/BinaryDecoder.java
+++ b/src/main/java/io/termd/core/io/BinaryDecoder.java
@@ -24,6 +24,7 @@ import java.nio.IntBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CoderResult;
+import java.nio.charset.CodingErrorAction;
 import java.util.function.Consumer;
 
 /**
@@ -47,6 +48,8 @@ public class BinaryDecoder {
       throw new IllegalArgumentException("Initial size must be at least 2");
     }
     decoder = charset.newDecoder();
+    decoder.onUnmappableCharacter(CodingErrorAction.REPLACE);
+    decoder.onMalformedInput(CodingErrorAction.REPLACE);
     bBuf = EMPTY;
     cBuf = CharBuffer.allocate(initialSize); // We need at least 2
     this.onChar = onChar;
@@ -59,6 +62,8 @@ public class BinaryDecoder {
    */
   public void setCharset(Charset charset) {
     decoder = charset.newDecoder();
+    decoder.onUnmappableCharacter(CodingErrorAction.REPLACE);
+    decoder.onMalformedInput(CodingErrorAction.REPLACE);
   }
 
   public void write(byte[] data) {

--- a/src/test/java/io/termd/core/io/BinaryDecoderTest.java
+++ b/src/test/java/io/termd/core/io/BinaryDecoderTest.java
@@ -1,0 +1,34 @@
+package io.termd.core.io;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a>
+ */
+public class BinaryDecoderTest {
+
+  @Test
+  public void shouldNotFailOnInvalidUtf8Sequence() {
+    List<String> hexes = new ArrayList<>();
+    Consumer<int[]> onChar = ints -> {
+      for (int i : ints) {
+        String hex = Integer.toHexString(i);
+        hexes.add(hex);
+      }
+    };
+    BinaryDecoder binaryDecoder = new BinaryDecoder(UTF_8, onChar);
+    byte[] bites = new byte[2];
+    bites[0] = (byte) Integer.parseInt("c3", 16);
+    bites[1] = (byte) Integer.parseInt("28", 16);
+    binaryDecoder.write(bites);
+
+    Assert.assertEquals("fffd", hexes.get(0));
+  }
+}


### PR DESCRIPTION
Avoid breaking process io reader (Pipe) on invalid byte sequence from process stdout.
Configure decoder to use `CodingErrorAction.REPLACE` instead of the default `CodingErrorAction.REPORT` which results in the exception.
Invalid sequence is replaced with the default replacement character � (FFFD).
```
Exception in thread "Thread-2" java.lang.UnsupportedOperationException: Handle me gracefully
	at io.termd.core.io.BinaryDecoder.write(BinaryDecoder.java:131)
	at io.termd.core.pty.PtyMaster$Pipe.run(PtyMaster.java:97)
```