### PR TITLE
Join stdOut and stdErr on native level.

### DIFF
--- a/src/main/java/io/termd/core/pty/PtyMaster.java
+++ b/src/main/java/io/termd/core/pty/PtyMaster.java
@@ -122,24 +122,15 @@ public class PtyMaster extends Thread {
   public void run() {
     ProcessBuilder builder = new ProcessBuilder(line.split("\\s+"));
     try {
+      builder.redirectErrorStream(true);
       process = builder.start();
       setStatus(Status.RUNNING);
       Pipe stdout = new Pipe(process.getInputStream());
-      Pipe stderr = new Pipe(process.getErrorStream());
       stdout.start();
-      stderr.start();
       try {
         log.debug("Waiting stdout to complete...");
         stdout.join();
         log.debug("Stdout completed.");
-      } catch (InterruptedException e) {
-        setStatus(Status.INTERRUPTED);
-        Thread.currentThread().interrupt();
-      }
-      try {
-        log.debug("Waiting stderr to complete...");
-        stderr.join();
-        log.debug("Stderr completed.");
       } catch (InterruptedException e) {
         setStatus(Status.INTERRUPTED);
         Thread.currentThread().interrupt();


### PR DESCRIPTION
Parallel reading of standard out and starndard error stream can result in wrong line order.

In particular when `set -x` is used in the script to echo the input commands, the output is sent to the stdError stream and when the command is long (especially when its response is short), the command itself is processed after its output.

